### PR TITLE
Provide support for the last five go versions via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: go
 
 go:
-  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
+  - '1.10'
   - tip
 
 go_import_path: github.com/reactivex/rxgo


### PR DESCRIPTION
Looking the gorilla/websocket travis settings on https://github.com/gorilla/websocket/blob/master/.travis.yml, we can see that the project supports go 1.7+ and that's could be the reason why our project is breaking with go 1.6 .
In this commit I'm setting four recent go versions (1.7 - 1.10) and the latest one to ensure that project is running correctly in those versions. As you can see it removes the 1.6 support and maybe we need to communicate that on readme.
You can see my builds on travis [here](https://travis-ci.org/cloudson/RxGo/builds/447166737). 

What do you guys think about that? 