### PR TITLE
Implement observable and emitter interfaces

### DIFF
--- a/rx/rx.go
+++ b/rx/rx.go
@@ -26,8 +26,8 @@ type Emitter interface {
 // Observable IS an Iterator that CAN Subscribe one or more
 // Observer(s) and immediately return an Emitter (see Emitter).
 type Observable interface {
-	// Iterator
-	Iterable
+	Iterator
+	//Iterable
 	Subscribe(Observer) Emitter
 }
 

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -1,38 +1,75 @@
 package subscription
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Subscription is usually returned from any subscription
 type Subscription struct {
-	SubscribeAt   time.Time
-	UnsubscribeAt time.Time
-	Error         error
+	ctx context.Context
+
+	SubscribeTime   time.Time
+	UnsubscribeTime time.Time
+	Error           error
 	//term          chan struct{}
 }
 
 // DefaultSubscription is a default Subscription.
-var DefaultSubscription = Subscription{}
+var DefaultSubscription = Subscription{
+	ctx: context.Background(),
+}
 
 // New creates a DefaultSubscription.
 func New() Subscription {
 	return DefaultSubscription
 }
 
-// Err returns an error recorded from a stream.
+//Deadline return when the emitter is completed, and whether or not a deadline is set.
+func (s Subscription) Deadline() (deadline time.Time, ok bool) {
+	return s.ctx.Deadline()
+}
+
+// Done returns a channel that signals when the emitter has completed.
+func (s Subscription) Done() <-chan struct{} {
+	return s.ctx.Done()
+}
+
+// Err returns the error that has occured for the emitter.
 func (s Subscription) Err() error {
-	return s.Error
+	if s.Error != nil {
+		return s.Error
+	}
+	return s.ctx.Err()
+}
+
+// Value assigns a key to the emitter.
+func (s Subscription) Value(key interface{}) interface{} {
+	return s.ctx.Value(key)
+}
+
+// SubscribeAt returns the time at which the subscription was subscribed.
+func (s Subscription) SubscribeAt() time.Time {
+	return s.SubscribeTime
 }
 
 // Subscribe records the time of subscription.
 func (s Subscription) Subscribe() Subscription {
-	s.SubscribeAt = time.Now()
+	s.SubscribeTime = time.Now()
 	return s
 }
 
 // Unsubscribe records the time of unsubscription.
 func (s Subscription) Unsubscribe() Subscription {
-	s.UnsubscribeAt = time.Now()
+	s.UnsubscribeTime = time.Now()
 	return s
+}
+
+//WithContext constructs a subscription with the specified context.
+func WithContext(ctx context.Context) Subscription {
+	return Subscription{
+		ctx: ctx,
+	}
 }
 
 /* TODO:

--- a/subscription/subscription_test.go
+++ b/subscription/subscription_test.go
@@ -1,18 +1,28 @@
 package subscription
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/reactivex/rxgo/rx"
+
 	"github.com/stretchr/testify/assert"
 )
+
+func TestImplementsEmitter(t *testing.T) {
+	var subscription interface{} = New()
+	_, isEmitter := subscription.(rx.Emitter)
+	assert.True(t, isEmitter, "subscription should be implementation of emitter interface")
+}
 
 func TestCreateSubscription(t *testing.T) {
 	sub := New()
 
 	assert := assert.New(t)
-	assert.Equal(time.Time{}, sub.SubscribeAt)
-	assert.Equal(time.Time{}, sub.UnsubscribeAt)
+	assert.Equal(time.Time{}, sub.SubscribeTime)
+	assert.Equal(time.Time{}, sub.UnsubscribeTime)
 	assert.Nil(sub.Err())
 }
 
@@ -27,6 +37,117 @@ func TestSubscription(t *testing.T) {
 	sub = sub.Unsubscribe()
 
 	assert := assert.New(t)
-	assert.WithinDuration(first, sub.SubscribeAt, 5*time.Millisecond)
-	assert.WithinDuration(first, sub.SubscribeAt, 15*time.Millisecond)
+	assert.WithinDuration(first, sub.SubscribeAt(), 5*time.Millisecond)
+	assert.WithinDuration(first, sub.SubscribeAt(), 15*time.Millisecond)
+}
+
+func TestConstructEmitterFromContext(t *testing.T) {
+	WithContext(context.Background())
+}
+
+func TestSubscriptionFromCancellableContext(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	emitter := WithContext(ctx)
+	done := emitter.Done()
+	cancelFunc()
+	select {
+	case <-done:
+		assert.EqualError(t, emitter.Err(), context.Canceled.Error())
+	default:
+		t.Error("cancelling the context did not signal the emitter")
+	}
+}
+
+func TestSubscriptionFromTimeoutContext(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(0)) //nolint
+	emitter := WithContext(ctx)
+	done := emitter.Done()
+	select {
+	case <-done:
+		assert.EqualError(t, emitter.Err(), context.DeadlineExceeded.Error())
+	default:
+		t.Error("cancelling the context did not signal the emitter")
+	}
+	cancelFunc()
+}
+
+func TestSubscriptionSubscribeAt(t *testing.T) {
+	ctx := context.Background()
+	subscription := WithContext(ctx)
+	beforeSubscription := time.Now()
+	subscription = subscription.Subscribe()
+	afterSubscription := time.Now()
+
+	emitterSubscriptionTime := subscription.SubscribeAt()
+	assert.True(t, emitterSubscriptionTime.After(beforeSubscription), "time less than a time evaluation before subscription")
+	assert.True(t, emitterSubscriptionTime.Before(afterSubscription), "time greater than time evaluation after subscription")
+}
+
+func TestSubscriptionDeadline(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(0))
+	emitter := WithContext(ctx)
+	deadline, deadlineSet := emitter.Deadline()
+	afterDeadlineTime := time.Now()
+	done := emitter.Done()
+	select {
+	case <-done:
+		assert.True(t, deadlineSet, "deadline should have been set")
+		assert.True(t, deadline.Before(afterDeadlineTime), "deadline should have occurred already")
+	default:
+		t.Error("cancelling the context did not signal the emitter")
+	}
+	cancelFunc()
+}
+
+func TestSubscriptionSettingError(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(0))
+	emitter := WithContext(ctx)
+	newFakeError := errors.New("some new error")
+	emitter.Error = newFakeError
+	done := emitter.Done()
+	select {
+	case <-done:
+		assert.EqualError(t, emitter.Err(), newFakeError.Error())
+	default:
+		t.Error("cancelling the context did not signal the emitter")
+	}
+	cancelFunc()
+}
+
+func TestSubscriptionValue(t *testing.T) {
+	type test struct {
+		ValuesToAssign map[interface{}]interface{}
+		KeyToSearch    interface{}
+		ExpectedResult interface{}
+	}
+	tests := []test{
+		test{
+			ValuesToAssign: map[interface{}]interface{}{"bob": 5},
+			KeyToSearch:    "bob",
+			ExpectedResult: 5},
+		test{
+			ValuesToAssign: map[interface{}]interface{}{},
+			KeyToSearch:    "john",
+			ExpectedResult: nil},
+		test{
+			ValuesToAssign: map[interface{}]interface{}{
+				true:     true,
+				false:    false,
+				"string": false,
+			},
+			KeyToSearch:    true,
+			ExpectedResult: true},
+	}
+	for _, test := range tests {
+		ctx := context.Background()
+		for k, v := range test.ValuesToAssign {
+			ctx = context.WithValue(ctx, k, v)
+		}
+		subscription := WithContext(ctx)
+		assert.Equal(t,
+			test.ExpectedResult,
+			subscription.Value(test.KeyToSearch),
+			"value from search was not equivalent to expected")
+	}
+
 }


### PR DESCRIPTION
The observable's subscribe function is modified to consume an observer and return a subscription. 
The subscription has been modified to return values from an internal context object. 