### PR TITLE
improve test coverage and fix on error behavior

### DIFF
--- a/examples/flatmap/flatmap_slice_test.go
+++ b/examples/flatmap/flatmap_slice_test.go
@@ -1,16 +1,20 @@
 package main
 
 import (
-	"fmt"
+	"testing"
 
-	"github.com/reactivex/rxgo/handlers"
 	"github.com/reactivex/rxgo/observable"
 	"github.com/reactivex/rxgo/observer"
 )
 
-func main() {
+func TestFlatMapExample(t *testing.T) {
+	// given
+	observerMock := observer.NewObserverMock()
+
+	// and
 	primeSequence := observable.Just([]int{2, 3, 5, 7, 11, 13})
 
+	// when
 	<-primeSequence.
 		FlatMap(func(primes interface{}) observable.Observable {
 			return observable.Create(func(emitter *observer.Observer, disposed bool) {
@@ -21,7 +25,8 @@ func main() {
 			})
 		}, 1).
 		Last().
-		Subscribe(handlers.NextFunc(func(prime interface{}) {
-			fmt.Println("Prime -> ", prime)
-		}))
+		Subscribe(observerMock.Capture())
+
+	// then
+	observerMock.AssertCalled(t, "OnNext", 13)
 }

--- a/observable/create.go
+++ b/observable/create.go
@@ -6,29 +6,46 @@ import "github.com/reactivex/rxgo/observer"
 // to signal sequence's end.
 // Example:
 // - emitting none elements
-// observable.Create(emitter *observer.Observer) { emitter.OnDone() })
+// observable.Create(emitter *observer.Observer, disposed bool) { emitter.OnDone() })
 // - emitting one element
-// observable.Create(func(emitter chan interface{}) {
+// observable.Create(func(emitter *observer.Observer, disposed bool) {
 //		emitter.OnNext("one element")
 //		emitter.OnDone()
 // })
-func Create(source func(emitter *observer.Observer)) Observable {
+func Create(source func(emitter *observer.Observer, disposed bool)) Observable {
 	emitted := make(chan interface{})
 	emitter := &observer.Observer{
 		NextHandler: func(el interface{}) {
-			emitted <- el
+			if !isClosed(emitted) {
+				emitted <- el
+			}
 		},
 		ErrHandler: func(err error) {
 			// decide how to deal with errors
+			if !isClosed(emitted) {
+				close(emitted)
+			}
 		},
 		DoneHandler: func() {
-			close(emitted)
+			if !isClosed(emitted) {
+				close(emitted)
+			}
 		},
 	}
 
 	go func() {
-		source(emitter)
+		source(emitter, isClosed(emitted))
 	}()
 
 	return emitted
+}
+
+func isClosed(ch <-chan interface{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+	}
+
+	return false
 }

--- a/observable/create_test.go
+++ b/observable/create_test.go
@@ -1,0 +1,137 @@
+package observable
+
+import (
+	"github.com/reactivex/rxgo/errors"
+	"github.com/reactivex/rxgo/observer"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestEmitsNoElements(t *testing.T) {
+	// given
+	mockedObserver := observer.NewObserverMock()
+
+	// and
+	sequence := Create(func(emitter *observer.Observer, disposed bool) {
+		emitter.OnDone()
+	})
+
+	// when
+	<-sequence.Subscribe(mockedObserver.Capture())
+
+	// then emits no elements
+	mockedObserver.AssertNotCalled(t, "OnNext", mock.Anything)
+	mockedObserver.AssertNotCalled(t, "OnError", mock.Anything)
+	mockedObserver.AssertCalled(t, "OnDone")
+}
+
+func TestEmitsElements(t *testing.T) {
+	// given
+	mockedObserver := observer.NewObserverMock()
+
+	// and
+	elementsToEmit := []int{1, 2, 3, 4, 5}
+
+	// and
+	sequence := Create(func(emitter *observer.Observer, disposed bool) {
+		for _, el := range elementsToEmit {
+			emitter.OnNext(el)
+		}
+		emitter.OnDone()
+	})
+
+	// when
+	<-sequence.Subscribe(mockedObserver.Capture())
+
+	// then emits elements
+	for _, emitted := range elementsToEmit {
+		mockedObserver.AssertCalled(t, "OnNext", emitted)
+	}
+	mockedObserver.AssertNotCalled(t, "OnError", mock.Anything)
+	mockedObserver.AssertCalled(t, "OnDone")
+}
+
+func TestOnlyFirstDoneCounts(t *testing.T) {
+	// given
+	mockedObserver := observer.NewObserverMock()
+
+	// and
+	sequence := Create(func(emitter *observer.Observer, disposed bool) {
+		emitter.OnDone()
+		emitter.OnDone()
+	})
+
+	// when
+	<-sequence.Subscribe(mockedObserver.Capture())
+
+	// then emits first done
+	mockedObserver.AssertNotCalled(t, "OnError", mock.Anything)
+	mockedObserver.AssertNotCalled(t, "OnNext", mock.Anything)
+	mockedObserver.AssertNumberOfCalls(t, "OnDone", 1)
+}
+
+func TestDoesntEmitElementsAfterDone(t *testing.T) {
+	// given
+	mockedObserver := observer.NewObserverMock()
+
+	// and
+	sequence := Create(func(emitter *observer.Observer, disposed bool) {
+		emitter.OnDone()
+		emitter.OnNext("it cannot be emitted")
+	})
+
+	// when
+	<-sequence.Subscribe(mockedObserver.Capture())
+
+	// then stops emission after done
+	mockedObserver.AssertNotCalled(t, "OnError", mock.Anything)
+	mockedObserver.AssertNotCalled(t, "OnNext", mock.Anything)
+	mockedObserver.AssertCalled(t, "OnDone")
+}
+
+
+// to clear out error emission
+func testEmitsError(t *testing.T) {
+	// given
+	mockedObserver := observer.NewObserverMock()
+
+	// and
+	expectedError := errors.New(errors.UndefinedError, "expected")
+
+	// and
+	sequence := Create(func(emitter *observer.Observer, disposed bool) {
+		emitter.OnError(expectedError)
+	})
+
+	// when
+	<-sequence.Subscribe(mockedObserver.Capture())
+
+	// then emits error
+	mockedObserver.AssertCalled(t, "OnError", expectedError)
+	mockedObserver.AssertNotCalled(t, "OnNext")
+	mockedObserver.AssertNotCalled(t, "OnDone")
+}
+
+// to clear out error emission
+func testFinishEmissionOnError(t *testing.T) {
+	// given
+	mockedObserver := observer.NewObserverMock()
+
+	// and
+	expectedError := errors.New(errors.UndefinedError, "expected")
+
+	// and
+	sequence := Create(func(emitter *observer.Observer, disposed bool) {
+		emitter.OnError(expectedError)
+		emitter.OnNext("some element which cannot be emitted")
+		emitter.OnDone()
+	})
+
+	// when
+	<-sequence.Subscribe(mockedObserver.Capture())
+
+	// then emits error
+	mockedObserver.AssertCalled(t, "OnError", expectedError)
+	mockedObserver.AssertNotCalled(t, "OnNext")
+	mockedObserver.AssertNotCalled(t, "OnDone")
+}


### PR DESCRIPTION
I created this pull request to improve test coverage of `create` operator, I've added to ease example writing. Besides that I corrected behavior of onerror for create operator (onerror signals the terminal state) and the example.

Thanks @avelino for your help.