### PR TITLE
Parallelize an observable subscription

### DIFF
--- a/observable/observable.go
+++ b/observable/observable.go
@@ -47,9 +47,15 @@ func (o Observable) Next() (interface{}, error) {
 }
 
 // Subscribe subscribes an EventHandler and returns a Subscription channel.
-func (o Observable) Subscribe(handler rx.EventHandler) <-chan subscription.Subscription {
+func (o Observable) Subscribe(handler rx.EventHandler, opts ...Option) <-chan subscription.Subscription {
 	done := make(chan subscription.Subscription)
 	sub := subscription.New().Subscribe()
+
+	// Parse options
+	var observableOptions options
+	for _, opt := range opts {
+		opt.apply(&observableOptions)
+	}
 
 	ob := CheckEventHandler(handler)
 
@@ -107,7 +113,7 @@ func (o Observable) Take(nth uint) Observable {
 	go func() {
 		takeCount := 0
 		for item := range o {
-			if (takeCount < int(nth)) {
+			if takeCount < int(nth) {
 				takeCount += 1
 				out <- item
 				continue
@@ -126,7 +132,7 @@ func (o Observable) TakeLast(nth uint) Observable {
 	go func() {
 		buf := make([]interface{}, nth)
 		for item := range o {
-			if (len(buf) >= int(nth)) {
+			if len(buf) >= int(nth) {
 				buf = buf[1:]
 			}
 			buf = append(buf, item)
@@ -218,14 +224,14 @@ func (o Observable) DistinctUntilChanged(apply fx.KeySelectorFunc) Observable {
 	return Observable(out)
 }
 
-// Skip suppresses the first n items in the original Observable and 
+// Skip suppresses the first n items in the original Observable and
 // returns a new Observable with the rest items.
 func (o Observable) Skip(nth uint) Observable {
 	out := make(chan interface{})
 	go func() {
 		skipCount := 0
 		for item := range o {
-			if (skipCount < int(nth)) {
+			if skipCount < int(nth) {
 				skipCount += 1
 				continue
 			}

--- a/observable/options.go
+++ b/observable/options.go
@@ -1,0 +1,31 @@
+package observable
+
+type Option interface {
+	apply(*options)
+}
+
+type options struct {
+	parallelism int
+}
+
+// funcOption wraps a function that modifies dialOptions into an
+// implementation of the DialOption interface.
+type funcOption struct {
+	f func(*options)
+}
+
+func (fdo *funcOption) apply(do *options) {
+	fdo.f(do)
+}
+
+func newFuncOption(f func(*options)) *funcOption {
+	return &funcOption{
+		f: f,
+	}
+}
+
+func WithParallelism(parallelism int) Option {
+	return newFuncOption(func(options *options) {
+		options.parallelism = parallelism
+	})
+}

--- a/observable/options.go
+++ b/observable/options.go
@@ -1,15 +1,17 @@
 package observable
 
+// Option is the configuration of an observable
 type Option interface {
 	apply(*options)
 }
 
+// options configurable for an observable
 type options struct {
 	parallelism int
 }
 
-// funcOption wraps a function that modifies dialOptions into an
-// implementation of the DialOption interface.
+// funcOption wraps a function that modifies options into an
+// implementation of the Option interface.
 type funcOption struct {
 	f func(*options)
 }
@@ -24,6 +26,7 @@ func newFuncOption(f func(*options)) *funcOption {
 	}
 }
 
+// WithParallelism allows to configure the level of parallelism
 func WithParallelism(parallelism int) Option {
 	return newFuncOption(func(options *options) {
 		options.parallelism = parallelism

--- a/observable/options_test.go
+++ b/observable/options_test.go
@@ -1,0 +1,15 @@
+package observable
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWithParallelism(t *testing.T) {
+	var observableOptions options
+
+	option := WithParallelism(2)
+	option.apply(&observableOptions)
+
+	assert.Equal(t, observableOptions.parallelism, 2)
+}


### PR DESCRIPTION
Hello,

First of, thanks for this project it's awesome.

**Pull request goal:** I wanted to make configurable the number of goroutines created during the subscription to an observable.

**Changes:**
* New `observable.options.go`: Mechanism to handle configurable options. The logic is similar to what we can find for example in the gRPC library ([example](https://github.com/grpc/grpc-go/blob/04ea82009cdb9ecdefc6289f4c93ec919a10b3b6/dialoptions.go)). For the time being, I've added a single concrete option: `WithParallelism` to configure the number of created goroutines.
* Changes to `observable.observable.go`: I changed the `Subscribe` method to get also a list of `Option`. I like this approach because the method remains backward-compatible. If the number of goroutines has been configured, I slightly modify the logic to create `n` goroutines for the observer and 1 goroutine to manage the publication end of a stream.
* Changes to `observable.observable_test.go`: I've added a `TestParallelSubscribeToObserver` test.

Please let me know what's your feeling about this change. Does it respect the philosophy of your library etc.

Thanks for your time :)