### PR TITLE
Reduce operator

### DIFF
--- a/fx/fx.go
+++ b/fx/fx.go
@@ -3,7 +3,6 @@
 package fx
 
 type (
-
 	// EmittableFunc defines a function that should be used with Start operator.
 	// EmittableFunc can be used to wrap a blocking operation.
 	EmittableFunc func() interface{}
@@ -16,7 +15,10 @@ type (
 
 	// FilterableFunc defines a func that should be passed to the Filter operator.
 	FilterableFunc func(interface{}) bool
-		
+
 	// KeySelectorFunc defines a func that should be passed to the Distinct operator.
 	KeySelectorFunc func(interface{}) interface{}
+
+	// ReducibleFunc defines a func that should be passed to the Reduce operator.
+	ReducibleFunc func(interface{}, interface{}) interface{}
 )

--- a/optional/optional.go
+++ b/optional/optional.go
@@ -1,0 +1,44 @@
+package optional
+
+var emptyOptional = new(empty)
+
+// Optional defines a container for empty values
+type Optional interface {
+	Get() interface{}
+	IsEmpty() bool
+}
+
+type some struct {
+	content interface{}
+}
+
+type empty struct {
+}
+
+func (s *some) Get() interface{} {
+	return s.content
+}
+
+func (s *some) IsEmpty() bool {
+	return false
+}
+
+func (e *empty) Get() interface{} {
+	return nil
+}
+
+func (e *empty) IsEmpty() bool {
+	return true
+}
+
+// Of returns a non empty optional
+func Of(data interface{}) Optional {
+	return &some{
+		content: data,
+	}
+}
+
+// Empty returns an empty optional
+func Empty() Optional {
+	return emptyOptional
+}

--- a/optional/optional_test.go
+++ b/optional/optional_test.go
@@ -1,0 +1,19 @@
+package optional
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOf(t *testing.T) {
+	some1 := Of("foo")
+	assert.False(t, some1.IsEmpty())
+	assert.Exactly(t, some1.Get(), "foo")
+
+	some2 := Of(nil)
+	assert.False(t, some2.IsEmpty())
+	assert.Nil(t, some2.Get())
+
+	empty := Empty()
+	assert.True(t, empty.IsEmpty())
+}


### PR DESCRIPTION
Implementation of the reduce operator. For this purpose, I also managed to dissociate empty from nil values by creating a so-called `Optional` container because I believe it was important to do so (that's the philosophy of other libraries like RxJava for example).

Meanwhile, there's a new `type OptionalObservable <-chan optional.Optional`.