### PR TITLE
ToList operator

### DIFF
--- a/observable/observable_test.go
+++ b/observable/observable_test.go
@@ -813,6 +813,32 @@ func TestObservableScanWithString(t *testing.T) {
 	assert.Exactly(t, expected, words)
 }
 
+func TestObservableToList(t *testing.T) {
+	items := []interface{}{1, "hello", false, .0}
+	it, err := iterable.New(items)
+	if err != nil {
+		t.Fail()
+	}
+
+	stream1 := From(it)
+
+	stream2 := stream1.ToList()
+
+	s := <-stream2
+
+	assert.Exactly(t, []interface{}{1, "hello", false, .0}, s)
+}
+
+func TestObservableToListWithEmpty(t *testing.T) {
+	stream1 := Empty()
+
+	stream2 := stream1.ToList()
+
+	s := <-stream2
+
+	assert.Exactly(t, []interface{}{}, s)
+}
+
 func TestRepeatInfinityOperator(t *testing.T) {
 	myStream := Repeat("mystring")
 


### PR DESCRIPTION
ToList operator implementation. It is based on a new type: `type SliceObservable <-chan []interface{}`.
Obviously, I could have reused the current `Observable` type but I feel like it would be easier/faster for the RxGo developers to automatically get an `[]interface{}` instead of having to cast it manually from an `interface{}`.