### PR TITLE
WithBufferedChannel option

### DIFF
--- a/observable/observable.go
+++ b/observable/observable.go
@@ -48,16 +48,19 @@ func (o Observable) Next() (interface{}, error) {
 
 // Subscribe subscribes an EventHandler and returns a Subscription channel.
 func (o Observable) Subscribe(handler rx.EventHandler, opts ...Option) <-chan subscription.Subscription {
-	done := make(chan subscription.Subscription)
-	sub := subscription.New().Subscribe()
-
-	ob := CheckEventHandler(handler)
-
 	// Parse options
 	var observableOptions options
-	for _, opt := range opts {
-		opt.apply(&observableOptions)
+	observableOptions.parseOptions(opts...)
+
+	var done chan subscription.Subscription
+	if observableOptions.channelBufferCapacity == 0 {
+		done = make(chan subscription.Subscription)
+	} else {
+		done = make(chan subscription.Subscription, observableOptions.channelBufferCapacity)
 	}
+
+	sub := subscription.New().Subscribe()
+	ob := CheckEventHandler(handler)
 
 	if observableOptions.parallelism == 0 {
 		go func() {

--- a/observable/options.go
+++ b/observable/options.go
@@ -7,7 +7,8 @@ type Option interface {
 
 // options configurable for an observable
 type options struct {
-	parallelism int
+	parallelism           int
+	channelBufferCapacity int
 }
 
 // funcOption wraps a function that modifies options into an
@@ -26,9 +27,24 @@ func newFuncOption(f func(*options)) *funcOption {
 	}
 }
 
+// parseOptions parse the given options and mutate the options
+// structure
+func (o *options) parseOptions(opts ...Option) {
+	for _, opt := range opts {
+		opt.apply(o)
+	}
+}
+
 // WithParallelism allows to configure the level of parallelism
 func WithParallelism(parallelism int) Option {
 	return newFuncOption(func(options *options) {
 		options.parallelism = parallelism
+	})
+}
+
+// WithBufferedChannel allows to configure the capacity of a buffered channel
+func WithBufferedChannel(capacity int) Option {
+	return newFuncOption(func(options *options) {
+		options.channelBufferCapacity = capacity
 	})
 }

--- a/observable/options_test.go
+++ b/observable/options_test.go
@@ -6,10 +6,17 @@ import (
 )
 
 func TestWithParallelism(t *testing.T) {
-	var observableOptions options
+	var o options
 
-	option := WithParallelism(2)
-	option.apply(&observableOptions)
+	WithParallelism(2).apply(&o)
 
-	assert.Equal(t, observableOptions.parallelism, 2)
+	assert.Equal(t, o.parallelism, 2)
+}
+
+func TestParseOptions(t *testing.T) {
+	var o options
+
+	o.parseOptions(WithParallelism(2))
+
+	assert.Equal(t, o.parallelism, 2)
 }


### PR DESCRIPTION
After that https://github.com/ReactiveX/RxGo/pull/78 was merged, I wanted to add another option: WithBufferedChannel to allow the configuration of the channel produced in the case of Map and Subscribe operators.

There's one thing to highlight though. Both operators are taking as an argument a `opts ...Option`. I just want to double check this is the direction we want to go.

The drawback of this alternative (all operator taking a list of common option) is that an user may for example configure an operator with an option that will not be taken into account. This is not going to fail but it will no be handled by the operator. We could just document it to make sure it is shared with the users.

The other alternative is to duplicate what we have in `option.go` and to manage maybe options per operator. This would result in a huge load of duplicated code in RxGo.

Hope my point is clear enough.