### PR TITLE
StartWith operator

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -18,22 +18,24 @@ type Assertion interface {
 	hasValueFunc() (bool, interface{})
 	hasRaisedErrorFunc() (bool, error)
 	hasRaisedAnErrorFunc() bool
+	hasNotRaisedAnErrorFunc() bool
 	isEmptyFunc() (bool, bool)
 }
 
 type assertion struct {
-	f                     func(*assertion)
-	checkHasItems         bool
-	hasItems              []interface{}
-	checkHasSize          bool
-	hasSize               int
-	checkHasValue         bool
-	hasValue              interface{}
-	checkHasRaisedError   bool
-	hasRaisedError        error
-	checkHasRaisedAnError bool
-	checkIsEmpty          bool
-	isEmpty               bool
+	f                        func(*assertion)
+	checkHasItems            bool
+	hasItems                 []interface{}
+	checkHasSize             bool
+	hasSize                  int
+	checkHasValue            bool
+	hasValue                 interface{}
+	checkHasRaisedError      bool
+	hasRaisedError           error
+	checkHasRaisedAnError    bool
+	checkHasNotRaisedAnError bool
+	checkIsEmpty             bool
+	isEmpty                  bool
 }
 
 func (ass *assertion) hasItemsFunc() (bool, []interface{}) {
@@ -54,6 +56,10 @@ func (ass *assertion) hasRaisedErrorFunc() (bool, error) {
 
 func (ass *assertion) hasRaisedAnErrorFunc() bool {
 	return ass.checkHasRaisedAnError
+}
+
+func (ass *assertion) hasNotRaisedAnErrorFunc() bool {
+	return ass.checkHasNotRaisedAnError
 }
 
 func (ass *assertion) isEmptyFunc() (bool, bool) {
@@ -133,6 +139,13 @@ func HasRaisedAnError() Assertion {
 	})
 }
 
+// HasNotRaisedAnError checks that a single does not raise an error.
+func HasNotRaisedAnError() Assertion {
+	return newAssertion(func(a *assertion) {
+		a.checkHasNotRaisedAnError = true
+	})
+}
+
 // AssertThatObservable asserts the result of an Observable against a list of assertions.
 func AssertThatObservable(t *testing.T, observable Observable, assertions ...Assertion) {
 	ass := parseAssertions(assertions...)
@@ -184,6 +197,11 @@ func AssertThatSingle(t *testing.T, single Single, assertions ...Assertion) {
 	checkHasRaisedError, value := ass.hasRaisedErrorFunc()
 	if checkHasRaisedError {
 		assert.Equal(t, value, err)
+	}
+
+	checkHasNotRaisedError := ass.hasNotRaisedAnErrorFunc()
+	if checkHasNotRaisedError {
+		assert.Nil(t, err)
 	}
 }
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -32,6 +32,10 @@ func TestAssertThatSingleError(t *testing.T) {
 		HasRaisedAnError(), HasRaisedError(errors.New("foo")))
 }
 
+func TestAssertThatSingleNotError(t *testing.T) {
+	AssertThatSingle(t, newSingleFrom(1), HasNotRaisedAnError())
+}
+
 func TestAssertThatOptionalSingleIsEmpty(t *testing.T) {
 	AssertThatOptionalSingle(t, newOptionalSingleFrom(optional.Empty()), IsEmpty())
 }

--- a/iterable/iterable_test.go
+++ b/iterable/iterable_test.go
@@ -4,13 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/reactivex/rxgo"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestIterableImplementsIterator(t *testing.T) {
-	assert.Implements(t, (*rxgo.Iterator)(nil), Iterable(nil))
-}
 
 func TestCreateHomogenousIterable(t *testing.T) {
 	ch := make(chan interface{})

--- a/observable.go
+++ b/observable.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/reactivex/rxgo/errors"
 	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/iterable"
 	"github.com/reactivex/rxgo/optional"
 	"github.com/reactivex/rxgo/options"
 )
@@ -53,6 +54,9 @@ type Observable interface {
 	Skip(nth uint) Observable
 	SkipLast(nth uint) Observable
 	SkipWhile(apply Predicate) Observable
+	StartWithItems(items ...interface{}) Observable
+	StartWithIterable(iterable iterable.Iterable) Observable
+	StartWithObservable(observable Observable) Observable
 	Subscribe(handler handlers.EventHandler, opts ...options.Option) Observer
 	Take(nth uint) Observable
 	TakeLast(nth uint) Observable
@@ -1178,6 +1182,68 @@ func (o *observable) BufferWithTimeOrCount(timespan Duration, count int) Observa
 			errCh <- nil
 		}()
 
+	}()
+	return &observable{ch: out}
+}
+
+// StartWithItems returns an Observable that emits the specified items before it begins to emit items emitted
+// by the source Observable.
+func (o *observable) StartWithItems(items ...interface{}) Observable {
+	out := make(chan interface{})
+	go func() {
+		for _, item := range items {
+			out <- item
+		}
+
+		for item := range o.ch {
+			out <- item
+		}
+
+		close(out)
+	}()
+	return &observable{ch: out}
+}
+
+// StartWithIterable returns an Observable that emits the items in a specified Iterable before it begins to
+// emit items emitted by the source Observable.
+func (o *observable) StartWithIterable(iterable iterable.Iterable) Observable {
+	out := make(chan interface{})
+	go func() {
+		for {
+			item, err := iterable.Next()
+			if err != nil {
+				break
+			}
+			out <- item
+		}
+
+		for item := range o.ch {
+			out <- item
+		}
+
+		close(out)
+	}()
+	return &observable{ch: out}
+}
+
+// StartWithObservable returns an Observable that emits the items in a specified Observable before it begins to
+// emit items emitted by the source Observable.
+func (o *observable) StartWithObservable(obs Observable) Observable {
+	out := make(chan interface{})
+	go func() {
+		for {
+			item, err := obs.Next()
+			if err != nil {
+				break
+			}
+			out <- item
+		}
+
+		for item := range o.ch {
+			out <- item
+		}
+
+		close(out)
 	}()
 	return &observable{ch: out}
 }


### PR DESCRIPTION
`StartWith` operator implementation:
* `StartWithItems` to start from a list of items
* `StartWithIterable` to start from a given `Iterable`
* `StartWithObservable` to start from a given `Observable`

Reference: http://reactivex.io/documentation/operators/startwith.html
Related issue: https://github.com/ReactiveX/RxGo/issues/135