### PR TITLE
Add Go 1.11+ module support for Version 2.

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -5,8 +5,8 @@ import (
 
 	"errors"
 
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/optional"
+	"github.com/reactivex/rxgo/v2/handlers"
+	"github.com/reactivex/rxgo/v2/optional"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/reactivex/rxgo/optional"
+	"github.com/reactivex/rxgo/v2/optional"
 )
 
 func TestAssertThatObservableHasItems(t *testing.T) {

--- a/connectableobservable.go
+++ b/connectableobservable.go
@@ -3,8 +3,8 @@ package rxgo
 import (
 	"sync"
 
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/options"
+	"github.com/reactivex/rxgo/v2/handlers"
+	"github.com/reactivex/rxgo/v2/options"
 )
 
 type ConnectableObservable interface {

--- a/connectableobservable_test.go
+++ b/connectableobservable_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/handlers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/flatmap/flatmap_slice.go
+++ b/examples/flatmap/flatmap_slice.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/reactivex/rxgo"
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2"
+	"github.com/reactivex/rxgo/v2/handlers"
 )
 
 func main() {

--- a/examples/flatmap/flatmap_slice_test.go
+++ b/examples/flatmap/flatmap_slice_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/reactivex/rxgo"
+	"github.com/reactivex/rxgo/v2"
 )
 
 func TestFlatMapExample(t *testing.T) {

--- a/examples/reactive_sum/sum.go
+++ b/examples/reactive_sum/sum.go
@@ -30,8 +30,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/reactivex/rxgo"
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2"
+	"github.com/reactivex/rxgo/v2/handlers"
 )
 
 func main() {

--- a/examples/scroll/server.go
+++ b/examples/scroll/server.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/reactivex/rxgo"
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2"
+	"github.com/reactivex/rxgo/v2/handlers"
 )
 
 var upgrader = websocket.Upgrader{

--- a/flatmap.go
+++ b/flatmap.go
@@ -3,12 +3,12 @@ package rxgo
 import (
 	"sync"
 
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/handlers"
 )
 
-// transforms emitted items into observables and flattens them into single observable.
-// maxInParallel argument controls how many transformed observables are processed in parallel
-// For an example please take a look at flatmap_slice_test.go file in the examples directory.
+// Transforms emitted items into Observables and flattens them into a single Observable.
+// The maxInParallel argument controls how many transformed Observables are processed in parallel.
+// For an example, please take a look at flatmap_slice_test.go in the examples directory.
 func (o *observable) FlatMap(apply func(interface{}) Observable, maxInParallel uint) Observable {
 	return o.flatMap(apply, maxInParallel, flatObservedSequence)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/reactivex/rxgo/v2
+
+require (
+	github.com/gorilla/websocket v1.4.0
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
+github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/iterable/iterable.go
+++ b/iterable/iterable.go
@@ -2,7 +2,7 @@
 // sequences of empty interface such as slice and channel to an Iterator.
 package iterable
 
-import "github.com/reactivex/rxgo/errors"
+import "github.com/reactivex/rxgo/v2/errors"
 
 // Iterable converts channel and slice into an Iterator.
 type Iterable <-chan interface{}

--- a/observable.go
+++ b/observable.go
@@ -6,11 +6,11 @@ import (
 
 	"fmt"
 
-	"github.com/reactivex/rxgo/errors"
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/iterable"
-	"github.com/reactivex/rxgo/optional"
-	"github.com/reactivex/rxgo/options"
+	"github.com/reactivex/rxgo/v2/errors"
+	"github.com/reactivex/rxgo/v2/handlers"
+	"github.com/reactivex/rxgo/v2/iterable"
+	"github.com/reactivex/rxgo/v2/optional"
+	"github.com/reactivex/rxgo/v2/options"
 )
 
 // Observable is a basic observable interface

--- a/observable_test.go
+++ b/observable_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/iterable"
-	"github.com/reactivex/rxgo/optional"
-	"github.com/reactivex/rxgo/options"
+	"github.com/reactivex/rxgo/v2/handlers"
+	"github.com/reactivex/rxgo/v2/iterable"
+	"github.com/reactivex/rxgo/v2/optional"
+	"github.com/reactivex/rxgo/v2/options"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/observablecreate.go
+++ b/observablecreate.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/reactivex/rxgo/errors"
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/errors"
+	"github.com/reactivex/rxgo/v2/handlers"
 )
 
 func isClosed(ch <-chan interface{}) bool {

--- a/observablecreate_test.go
+++ b/observablecreate_test.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"time"
 
-	rxerrors "github.com/reactivex/rxgo/errors"
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/iterable"
+	rxerrors "github.com/reactivex/rxgo/v2/errors"
+	"github.com/reactivex/rxgo/v2/handlers"
+	"github.com/reactivex/rxgo/v2/iterable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/observer.go
+++ b/observer.go
@@ -3,7 +3,7 @@ package rxgo
 import (
 	"sync"
 
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/handlers"
 )
 
 // Observer represents a group of EventHandlers.

--- a/observer_mock.go
+++ b/observer_mock.go
@@ -1,7 +1,7 @@
 package rxgo
 
 import (
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/handlers"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/observer_test.go
+++ b/observer_test.go
@@ -5,7 +5,7 @@ import (
 
 	"errors"
 
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/handlers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/optional/optional.go
+++ b/optional/optional.go
@@ -1,6 +1,6 @@
 package optional
 
-import "github.com/reactivex/rxgo/errors"
+import "github.com/reactivex/rxgo/v2/errors"
 
 var emptyOptional = new(empty)
 

--- a/optional/optional_test.go
+++ b/optional/optional_test.go
@@ -3,7 +3,7 @@ package optional
 import (
 	"testing"
 
-	"github.com/reactivex/rxgo/errors"
+	"github.com/reactivex/rxgo/v2/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/single.go
+++ b/single.go
@@ -1,9 +1,9 @@
 package rxgo
 
 import (
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/optional"
-	"github.com/reactivex/rxgo/options"
+	"github.com/reactivex/rxgo/v2/handlers"
+	"github.com/reactivex/rxgo/v2/optional"
+	"github.com/reactivex/rxgo/v2/options"
 )
 
 // Single is similar to an Observable but emits only one single element or an error notification.

--- a/single_test.go
+++ b/single_test.go
@@ -3,8 +3,8 @@ package rxgo
 import (
 	"testing"
 
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/optional"
+	"github.com/reactivex/rxgo/v2/handlers"
+	"github.com/reactivex/rxgo/v2/optional"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/singleobserver.go
+++ b/singleobserver.go
@@ -3,7 +3,7 @@ package rxgo
 import (
 	"sync"
 
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/handlers"
 )
 
 // SingleObserver represents a group of EventHandlers.

--- a/singleobserver_test.go
+++ b/singleobserver_test.go
@@ -3,7 +3,7 @@ package rxgo
 import (
 	"testing"
 
-	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/v2/handlers"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This also changes the include path to github.com/reactivex/rxgo/v2 for
semantic versioning support.

See https://github.com/golang/go/wiki/Modules for information on why
this is a "good idea".