### PR TITLE
Add Go 1.11+ module support for Version 2.

### DIFF
--- a/flatmap.go
+++ b/flatmap.go
@@ -6,9 +6,9 @@ import (
 	"github.com/reactivex/rxgo/handlers"
 )
 
-// transforms emitted items into observables and flattens them into single observable.
-// maxInParallel argument controls how many transformed observables are processed in parallel
-// For an example please take a look at flatmap_slice_test.go file in the examples directory.
+// Transforms emitted items into Observables and flattens them into a single Observable.
+// The maxInParallel argument controls how many transformed Observables are processed in parallel.
+// For an example, please take a look at flatmap_slice_test.go in the examples directory.
 func (o *observable) FlatMap(apply func(interface{}) Observable, maxInParallel uint) Observable {
 	return o.flatMap(apply, maxInParallel, flatObservedSequence)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/reactivex/rxgo
+
+require (
+	github.com/gorilla/websocket v1.4.0
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
+github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
See https://github.com/golang/go/wiki/Modules for information on why
this is a "good idea".