### PR TITLE
Use an empty struct channel instead of Mutex to protect Observer.disposed

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -1,8 +1,6 @@
 package rxgo
 
 import (
-	"sync"
-
 	"github.com/reactivex/rxgo/handlers"
 )
 
@@ -19,31 +17,30 @@ type Observer interface {
 }
 
 type observer struct {
-	disposedMutex sync.Mutex
-	disposed      bool
-	nextHandler   handlers.NextFunc
-	errHandler    handlers.ErrFunc
-	doneHandler   handlers.DoneFunc
-	done          chan error
+	disposed    chan struct{}
+	nextHandler handlers.NextFunc
+	errHandler  handlers.ErrFunc
+	doneHandler handlers.DoneFunc
+	done        chan error
 }
 
 // NewObserver constructs a new Observer instance with default Observer and accept
 // any number of EventHandler
 func NewObserver(eventHandlers ...handlers.EventHandler) Observer {
-	ob := observer{}
+	ob := observer{
+		disposed: make(chan struct{}),
+	}
 
-	if len(eventHandlers) > 0 {
-		for _, handler := range eventHandlers {
-			switch handler := handler.(type) {
-			case handlers.NextFunc:
-				ob.nextHandler = handler
-			case handlers.ErrFunc:
-				ob.errHandler = handler
-			case handlers.DoneFunc:
-				ob.doneHandler = handler
-			case *observer:
-				ob = *handler
-			}
+	for _, handler := range eventHandlers {
+		switch handler := handler.(type) {
+		case handlers.NextFunc:
+			ob.nextHandler = handler
+		case handlers.ErrFunc:
+			ob.errHandler = handler
+		case handlers.DoneFunc:
+			ob.doneHandler = handler
+		case *observer:
+			ob = *handler
 		}
 	}
 
@@ -66,31 +63,27 @@ func (o *observer) Handle(item interface{}) {
 	switch item := item.(type) {
 	case error:
 		o.errHandler(item)
-		return
 	default:
 		o.nextHandler(item)
 	}
 }
 
 func (o *observer) Dispose() {
-	o.disposedMutex.Lock()
-	o.disposed = true
-	o.disposedMutex.Unlock()
+	close(o.disposed)
 }
 
 func (o *observer) IsDisposed() bool {
-	o.disposedMutex.Lock()
-	defer o.disposedMutex.Unlock()
-	return o.disposed
+	select {
+	case <-o.disposed:
+		return true
+	default:
+		return false
+	}
 }
 
 // OnNext applies Observer's NextHandler to an Item
 func (o *observer) OnNext(item interface{}) {
-	o.disposedMutex.Lock()
-	disposed := o.disposed
-	o.disposedMutex.Unlock()
-
-	if !disposed {
+	if !o.IsDisposed() {
 		switch item := item.(type) {
 		case error:
 			return
@@ -106,10 +99,7 @@ func (o *observer) OnNext(item interface{}) {
 
 // OnError applies Observer's ErrHandler to an error
 func (o *observer) OnError(err error) {
-	o.disposedMutex.Lock()
-	disposed := o.disposed
-	o.disposedMutex.Unlock()
-	if !disposed {
+	if !o.IsDisposed() {
 		if o.errHandler != nil {
 			o.errHandler(err)
 			o.Dispose()
@@ -125,10 +115,7 @@ func (o *observer) OnError(err error) {
 
 // OnDone terminates the Observer's internal Observable
 func (o *observer) OnDone() {
-	o.disposedMutex.Lock()
-	disposed := o.disposed
-	o.disposedMutex.Unlock()
-	if !disposed {
+	if !o.IsDisposed() {
 		if o.doneHandler != nil {
 			o.doneHandler()
 			o.Dispose()
@@ -144,10 +131,7 @@ func (o *observer) OnDone() {
 
 // OnDone terminates the Observer's internal Observable
 func (o *observer) Block() error {
-	o.disposedMutex.Lock()
-	disposed := o.disposed
-	o.disposedMutex.Unlock()
-	if !disposed {
+	if !o.IsDisposed() {
 		for v := range o.done {
 			return v
 		}

--- a/singleobserver.go
+++ b/singleobserver.go
@@ -1,8 +1,6 @@
 package rxgo
 
 import (
-	"sync"
-
 	"github.com/reactivex/rxgo/handlers"
 )
 
@@ -18,17 +16,18 @@ type SingleObserver interface {
 }
 
 type singleObserver struct {
-	disposedMutex sync.Mutex
-	disposed      bool
-	nextHandler   handlers.NextFunc
-	errHandler    handlers.ErrFunc
-	done          chan interface{}
+	disposed    chan struct{}
+	nextHandler handlers.NextFunc
+	errHandler  handlers.ErrFunc
+	done        chan interface{}
 }
 
 // NewSinglesingleObserver constructs a new SingleObserver instance with default SingleObserver and accept
 // any number of EventHandler
 func NewSingleObserver(eventHandlers ...handlers.EventHandler) SingleObserver {
-	ob := singleObserver{}
+	ob := singleObserver{
+		disposed: make(chan struct{}),
+	}
 
 	if len(eventHandlers) > 0 {
 		for _, handler := range eventHandlers {
@@ -66,23 +65,21 @@ func (o *singleObserver) Handle(item interface{}) {
 }
 
 func (o *singleObserver) Dispose() {
-	o.disposedMutex.Lock()
-	o.disposed = true
-	o.disposedMutex.Unlock()
+	close(o.disposed)
 }
 
 func (o *singleObserver) IsDisposed() bool {
-	o.disposedMutex.Lock()
-	defer o.disposedMutex.Unlock()
-	return o.disposed
+	select {
+	case <-o.disposed:
+		return true
+	default:
+		return false
+	}
 }
 
 // OnNext applies SingleObserver's NextHandler to an Item
 func (o *singleObserver) OnSuccess(item interface{}) {
-	o.disposedMutex.Lock()
-	disposed := o.disposed
-	o.disposedMutex.Unlock()
-	if !disposed {
+	if !o.IsDisposed() {
 		switch item := item.(type) {
 		case error:
 			return
@@ -103,10 +100,7 @@ func (o *singleObserver) OnSuccess(item interface{}) {
 
 // OnError applies SingleObserver's ErrHandler to an error
 func (o *singleObserver) OnError(err error) {
-	o.disposedMutex.Lock()
-	disposed := o.disposed
-	o.disposedMutex.Unlock()
-	if !disposed {
+	if !o.IsDisposed() {
 		if o.errHandler != nil {
 			o.errHandler(err)
 			o.Dispose()
@@ -122,10 +116,7 @@ func (o *singleObserver) OnError(err error) {
 
 // OnDone terminates the SingleObserver's internal Observable
 func (o *singleObserver) Block() (interface{}, error) {
-	o.disposedMutex.Lock()
-	disposed := o.disposed
-	o.disposedMutex.Unlock()
-	if !disposed {
+	if !o.IsDisposed() {
 		for v := range o.done {
 			switch v := v.(type) {
 			case error:

--- a/singleobserver_test.go
+++ b/singleobserver_test.go
@@ -36,3 +36,14 @@ func TestCreateNewSingleObserverFromSingleObserver(t *testing.T) {
 	assert.Equal(t, int64(3), v)
 	assert.True(t, single.IsDisposed())
 }
+
+func BenchmarkIsDisposed(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		o := NewSingleObserver()
+		for i := 0; i < 10; i++ {
+			o.IsDisposed()
+		}
+		o.Dispose()
+		o.IsDisposed()
+	}
+}


### PR DESCRIPTION
This changes o.disposed in Observer and SingleObserver from a Mutex
protected bool to a channel of struct{}. Once the channel is closed,
that's considered "disposed", and avoids reglar mutex synchronisation.

Included is a benchmark (`go test -race -bench=. ./...`) to test what I
assume is a regular use of IsDisposed on Observer and SingleObserver.

The original code:
```
BenchmarkIsDisposed-8             300000              4776 ns/op
```

After this change:
```
BenchmarkIsDisposed-8            1000000              1138 ns/op
```

It's roughly 4x faster using a channel instead of a Mutex.