### PR TITLE
Merge infinite loop and short circuit

### DIFF
--- a/observablecreate.go
+++ b/observablecreate.go
@@ -336,8 +336,8 @@ func Merge(observable Observable, observables ...Observable) Observable {
 	wg := sync.WaitGroup{}
 
 	f := func(o Observable) {
+		it := o.Iterator(context.Background())
 		for {
-			it := o.Iterator(context.Background())
 			if item, err := it.Next(context.Background()); err == nil {
 				out <- item
 			} else {

--- a/observablecreate.go
+++ b/observablecreate.go
@@ -336,13 +336,13 @@ func Merge(observable Observable, observables ...Observable) Observable {
 	wg := sync.WaitGroup{}
 
 	f := func(o Observable) {
+		wg.Done()
 		it := o.Iterator(context.Background())
 		for {
 			if item, err := it.Next(context.Background()); err == nil {
 				out <- item
 			} else {
 				break
-				wg.Done()
 			}
 		}
 	}


### PR DESCRIPTION
The emitter lambda of the Merge operator requests a new iterator in each repetition of the for loop. For at least 'iterableFromSlice' and probably in the general case of any iterable which does not consume the iterated (iterableFromRange?), this repeats the first iteration infinitely.