### PR TITLE
Causality testing API

### DIFF
--- a/connectableobservable.go
+++ b/connectableobservable.go
@@ -289,8 +289,8 @@ func (c *connectableObservable) TakeWhile(apply Predicate) Observable {
 	return c.observable.TakeWhile(apply)
 }
 
-func (c *connectableObservable) Timeout(duration Duration) Observable {
-	return c.observable.Timeout(duration)
+func (c *connectableObservable) Timeout(observable Observable) Observable {
+	return c.observable.Timeout(observable)
 }
 
 func (c *connectableObservable) ToChannel(opts ...options.Option) Channel {

--- a/observable.go
+++ b/observable.go
@@ -1671,16 +1671,13 @@ func (o *observable) TakeWhile(apply Predicate) Observable {
 
 func (o *observable) Timeout(observable Observable) Observable {
 	f := func(out chan interface{}) {
-		fmt.Printf("%v\n", "f")
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
 			it := o.Iterator(ctx)
 			for {
 				if item, err := it.Next(ctx); err == nil {
-					fmt.Printf("%v\n", item)
 					out <- item
 				} else {
-					fmt.Printf("cancel\n")
 					out <- err
 					break
 				}
@@ -1688,8 +1685,7 @@ func (o *observable) Timeout(observable Observable) Observable {
 		}()
 		go func() {
 			it := observable.Iterator(context.Background())
-			next, e := it.Next(context.Background())
-			fmt.Printf("%v %v\n", next, e)
+			it.Next(context.Background())
 			cancel()
 		}()
 	}

--- a/observable_mock_test.go
+++ b/observable_mock_test.go
@@ -3,12 +3,13 @@ package rxgo
 import (
 	"bufio"
 	"context"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const signalCh = byte(0)

--- a/observable_mock_test.go
+++ b/observable_mock_test.go
@@ -3,36 +3,16 @@ package rxgo
 import (
 	"bufio"
 	"context"
-	"github.com/reactivex/rxgo/handlers"
-	"github.com/reactivex/rxgo/options"
 	"github.com/stretchr/testify/mock"
 	"strconv"
 	"strings"
-	"testing"
 )
 
-func newSyncObservable(iterator Iterator) Observable {
-	return &observable{
-		observableType: cold,
-		iterable: &syncIterable{
-			iterator: iterator,
-		},
-	}
-}
-
-type syncIterable struct {
+type mockIterable struct {
 	iterator Iterator
 }
 
-func (s *syncIterable) Iterator(ctx context.Context) Iterator {
-	return s.iterator
-}
-
-type MockObservable struct {
-	mock.Mock
-}
-
-type MockIterator struct {
+type mockIterator struct {
 	mock.Mock
 }
 
@@ -42,8 +22,17 @@ type task struct {
 	close      bool
 }
 
-func TestMockIterators(t *testing.T) {
-	mockIterators("1:1,1:2,2:0,1:3,1:4,2:0,1:5,1:6,2:0,1:close,2:close")
+func (s *mockIterable) Iterator(ctx context.Context) Iterator {
+	return s.iterator
+}
+
+func mockObservable(iterator Iterator) Observable {
+	return &observable{
+		observableType: cold,
+		iterable: &mockIterable{
+			iterator: iterator,
+		},
+	}
 }
 
 func countTab(line string) int {
@@ -58,7 +47,7 @@ func countTab(line string) int {
 	return i
 }
 
-func mockIterators(in string) ([]*MockIterator, error) {
+func mockIterators(in string) ([]*mockIterator, error) {
 	scanner := bufio.NewScanner(strings.NewReader(in))
 	m := make(map[int]int)
 	tasks := make([]task, 0)
@@ -91,10 +80,10 @@ func mockIterators(in string) ([]*MockIterator, error) {
 		}
 	}
 
-	observables := make([]*MockIterator, 0, len(m))
+	observables := make([]*mockIterator, 0, len(m))
 	calls := make([]*mock.Call, len(m))
 	for i := 0; i < len(m); i++ {
-		observables = append(observables, new(MockIterator))
+		observables = append(observables, new(mockIterator))
 	}
 
 	item, err := args(tasks[0])
@@ -102,20 +91,20 @@ func mockIterators(in string) ([]*MockIterator, error) {
 	calls[0] = call
 
 	var lastCh chan struct{}
-	lastObs := tasks[0].observable
+	lastObservableType := tasks[0].observable
 	for i := 1; i < len(tasks); i++ {
 		t := tasks[i]
 		index := m[t.observable]
 		obs := observables[index]
 		item, err := args(t)
-		if lastObs == t.observable {
+		if lastObservableType == t.observable {
 			if calls[index] == nil {
 				calls[index] = obs.On("Next", mock.Anything).Once().Return(item, err)
 			} else {
 				calls[index].On("Next", mock.Anything).Once().Return(item, err)
 			}
 		} else {
-			lastObs = t.observable
+			lastObservableType = t.observable
 			if lastCh == nil {
 				ch := make(chan struct{})
 				lastCh = ch
@@ -167,262 +156,7 @@ func run(wait chan struct{}, send chan struct{}) {
 	}
 }
 
-func (m *MockIterator) Next(ctx context.Context) (interface{}, error) {
+func (m *mockIterator) Next(ctx context.Context) (interface{}, error) {
 	args := m.Called(ctx)
 	return args.Get(0), args.Error(1)
-}
-
-func (m *MockObservable) Iterator(ctx context.Context) Iterator {
-	args := m.Called(ctx)
-	return args.Get(0).(Iterator)
-}
-
-func (m *MockObservable) All(predicate Predicate) Single {
-	args := m.Called(predicate)
-	return args.Get(0).(Single)
-}
-
-func (m *MockObservable) AverageFloat32() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) AverageFloat64() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) AverageInt() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) AverageInt8() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) AverageInt16() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) AverageInt32() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) AverageInt64() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) BufferWithCount(count, skip int) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) BufferWithTime(timespan, timeshift Duration) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) BufferWithTimeOrCount(timespan Duration, count int) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Contains(equal Predicate) Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) Count() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) DefaultIfEmpty(defaultValue interface{}) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Distinct(apply Function) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) DistinctUntilChanged(apply Function) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) DoOnEach(onNotification Consumer) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) ElementAt(index uint) Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) Filter(apply Predicate) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) First() Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) FirstOrDefault(defaultValue interface{}) Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) FlatMap(apply func(interface{}) Observable, maxInParallel uint) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) ForEach(nextFunc handlers.NextFunc, errFunc handlers.ErrFunc,
-	doneFunc handlers.DoneFunc, opts ...options.Option) Observer {
-	panic("implement me")
-}
-
-func (m *MockObservable) IgnoreElements() Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Last() Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) LastOrDefault(defaultValue interface{}) Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) Map(apply Function) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Max(comparator Comparator) OptionalSingle {
-	panic("implement me")
-}
-
-func (m *MockObservable) Min(comparator Comparator) OptionalSingle {
-	panic("implement me")
-}
-
-func (m *MockObservable) OnErrorResumeNext(resumeSequence ErrorToObservableFunction) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) OnErrorReturn(resumeFunc ErrorFunction) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) OnErrorReturnItem(item interface{}) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Publish() ConnectableObservable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Reduce(apply Function2) OptionalSingle {
-	panic("implement me")
-}
-
-func (m *MockObservable) Repeat(count int64, frequency Duration) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Sample(obs Observable) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Scan(apply Function2) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) SequenceEqual(obs Observable) Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) Skip(nth uint) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) SkipLast(nth uint) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) SkipWhile(apply Predicate) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) StartWithItems(item interface{}, items ...interface{}) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) StartWithIterable(iterable Iterable) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) StartWithObservable(observable Observable) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Subscribe(handler handlers.EventHandler, opts ...options.Option) Observer {
-	panic("implement me")
-}
-
-func (m *MockObservable) SumFloat32() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) SumFloat64() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) SumInt64() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) Take(nth uint) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) TakeLast(nth uint) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) TakeUntil(apply Predicate) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) TakeWhile(apply Predicate) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) Timeout(duration Duration) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) ToChannel(opts ...options.Option) Channel {
-	panic("implement me")
-}
-
-func (m *MockObservable) ToMap(keySelector Function) Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) ToMapWithValueSelector(keySelector, valueSelector Function) Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) ToSlice() Single {
-	panic("implement me")
-}
-
-func (m *MockObservable) ZipFromObservable(publisher Observable, zipper Function2) Observable {
-	panic("implement me")
-}
-
-func (m *MockObservable) getIgnoreElements() bool {
-	panic("implement me")
-}
-
-func (m *MockObservable) getOnErrorResumeNext() ErrorToObservableFunction {
-	panic("implement me")
-}
-
-func (m *MockObservable) getOnErrorReturn() ErrorFunction {
-	panic("implement me")
-}
-
-func (m *MockObservable) getOnErrorReturnItem() interface{} {
-	panic("implement me")
 }

--- a/observable_mock_test.go
+++ b/observable_mock_test.go
@@ -1,0 +1,411 @@
+package rxgo
+
+import (
+	"bufio"
+	"context"
+	"github.com/reactivex/rxgo/handlers"
+	"github.com/reactivex/rxgo/options"
+	"github.com/stretchr/testify/mock"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type MockObservable struct {
+	mock.Mock
+}
+
+type MockIterator struct {
+	mock.Mock
+}
+
+type task struct {
+	observable int
+	item       int
+	close      bool
+}
+
+func TestMockIterators(t *testing.T) {
+	mockIterators("1:1,1:2,2:0,1:3,1:4,2:0,1:5,1:6,2:0,1:close,2:close")
+}
+
+func countTab(line string) int {
+	i := 0
+	for _, runeValue := range line {
+		if runeValue == '\t' {
+			i++
+		} else {
+			break
+		}
+	}
+	return i
+}
+
+func mockIterators(in string) ([]*MockIterator, error) {
+	scanner := bufio.NewScanner(strings.NewReader(in))
+	m := make(map[int]int)
+	tasks := make([]task, 0)
+	count := 0
+	for scanner.Scan() {
+		s := scanner.Text()
+		if s == "" {
+			continue
+		}
+		observable := countTab(s)
+		v := strings.TrimSpace(s)
+		if v == "x" {
+			tasks = append(tasks, task{
+				observable: observable,
+				close:      true,
+			})
+		} else {
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, err
+			}
+			tasks = append(tasks, task{
+				observable: observable,
+				item:       n,
+			})
+		}
+		if _, contains := m[observable]; !contains {
+			m[observable] = count
+			count++
+		}
+	}
+
+	observables := make([]*MockIterator, 0, len(m))
+	calls := make([]*mock.Call, len(m))
+	for i := 0; i < len(m); i++ {
+		observables = append(observables, new(MockIterator))
+	}
+
+	item, err := args(tasks[0])
+	call := observables[0].On("Next", mock.Anything).Once().Return(item, err)
+	calls[0] = call
+
+	var lastCh chan struct{}
+	lastObs := tasks[0].observable
+	for i := 1; i < len(tasks); i++ {
+		t := tasks[i]
+		index := m[t.observable]
+		obs := observables[index]
+		item, err := args(t)
+		if lastObs == t.observable {
+			if calls[index] == nil {
+				calls[index] = obs.On("Next", mock.Anything).Once().Arguments.Return(item, err)
+			} else {
+				calls[index].On("Next", mock.Anything).Once().Return(item, err)
+			}
+		} else {
+			lastObs = t.observable
+			if lastCh == nil {
+				ch := make(chan struct{})
+				lastCh = ch
+				if calls[index] == nil {
+					calls[index] = obs.On("Next", mock.Anything).Once().Return(item, err).
+						Run(func(args mock.Arguments) {
+							run(ch, nil)
+						})
+				} else {
+					calls[index].On("Next", mock.Anything).Once().Return(item, err).
+						Run(func(args mock.Arguments) {
+							run(ch, nil)
+						})
+				}
+			} else {
+				ch := make(chan struct{})
+				previous := lastCh
+				if calls[index] == nil {
+					calls[index] = obs.On("Next", mock.Anything).Once().Return(item, err).
+						Run(func(args mock.Arguments) {
+							run(ch, previous)
+						})
+				} else {
+					calls[index].On("Next", mock.Anything).Once().Return(item, err).
+						Run(func(args mock.Arguments) {
+							run(ch, previous)
+						})
+				}
+				lastCh = ch
+			}
+		}
+	}
+	return observables, nil
+}
+
+func args(t task) (interface{}, error) {
+	if t.close {
+		return nil, &NoSuchElementError{}
+	}
+	return t.item, nil
+}
+
+func run(wait chan struct{}, send chan struct{}) {
+	if send != nil {
+		send <- struct{}{}
+	}
+	if wait != nil {
+		<-wait
+	}
+}
+
+func (m *MockIterator) Next(ctx context.Context) (interface{}, error) {
+	args := m.Called(ctx)
+	return args.Get(0), args.Error(1)
+}
+
+func (m *MockObservable) Iterator(ctx context.Context) Iterator {
+	args := m.Called(ctx)
+	return args.Get(0).(Iterator)
+}
+
+func (m *MockObservable) All(predicate Predicate) Single {
+	args := m.Called(predicate)
+	return args.Get(0).(Single)
+}
+
+func (m *MockObservable) AverageFloat32() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) AverageFloat64() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) AverageInt() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) AverageInt8() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) AverageInt16() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) AverageInt32() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) AverageInt64() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) BufferWithCount(count, skip int) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) BufferWithTime(timespan, timeshift Duration) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) BufferWithTimeOrCount(timespan Duration, count int) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Contains(equal Predicate) Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) Count() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) DefaultIfEmpty(defaultValue interface{}) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Distinct(apply Function) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) DistinctUntilChanged(apply Function) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) DoOnEach(onNotification Consumer) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) ElementAt(index uint) Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) Filter(apply Predicate) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) First() Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) FirstOrDefault(defaultValue interface{}) Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) FlatMap(apply func(interface{}) Observable, maxInParallel uint) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) ForEach(nextFunc handlers.NextFunc, errFunc handlers.ErrFunc,
+	doneFunc handlers.DoneFunc, opts ...options.Option) Observer {
+	panic("implement me")
+}
+
+func (m *MockObservable) IgnoreElements() Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Last() Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) LastOrDefault(defaultValue interface{}) Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) Map(apply Function) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Max(comparator Comparator) OptionalSingle {
+	panic("implement me")
+}
+
+func (m *MockObservable) Min(comparator Comparator) OptionalSingle {
+	panic("implement me")
+}
+
+func (m *MockObservable) OnErrorResumeNext(resumeSequence ErrorToObservableFunction) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) OnErrorReturn(resumeFunc ErrorFunction) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) OnErrorReturnItem(item interface{}) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Publish() ConnectableObservable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Reduce(apply Function2) OptionalSingle {
+	panic("implement me")
+}
+
+func (m *MockObservable) Repeat(count int64, frequency Duration) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Sample(obs Observable) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Scan(apply Function2) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) SequenceEqual(obs Observable) Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) Skip(nth uint) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) SkipLast(nth uint) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) SkipWhile(apply Predicate) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) StartWithItems(item interface{}, items ...interface{}) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) StartWithIterable(iterable Iterable) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) StartWithObservable(observable Observable) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Subscribe(handler handlers.EventHandler, opts ...options.Option) Observer {
+	panic("implement me")
+}
+
+func (m *MockObservable) SumFloat32() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) SumFloat64() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) SumInt64() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) Take(nth uint) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) TakeLast(nth uint) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) TakeUntil(apply Predicate) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) TakeWhile(apply Predicate) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) Timeout(duration Duration) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) ToChannel(opts ...options.Option) Channel {
+	panic("implement me")
+}
+
+func (m *MockObservable) ToMap(keySelector Function) Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) ToMapWithValueSelector(keySelector, valueSelector Function) Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) ToSlice() Single {
+	panic("implement me")
+}
+
+func (m *MockObservable) ZipFromObservable(publisher Observable, zipper Function2) Observable {
+	panic("implement me")
+}
+
+func (m *MockObservable) getIgnoreElements() bool {
+	panic("implement me")
+}
+
+func (m *MockObservable) getOnErrorResumeNext() ErrorToObservableFunction {
+	panic("implement me")
+}
+
+func (m *MockObservable) getOnErrorReturn() ErrorFunction {
+	panic("implement me")
+}
+
+func (m *MockObservable) getOnErrorReturnItem() interface{} {
+	panic("implement me")
+}

--- a/observable_mock_test.go
+++ b/observable_mock_test.go
@@ -11,6 +11,23 @@ import (
 	"testing"
 )
 
+func newSyncObservable(iterator Iterator) Observable {
+	return &observable{
+		observableType: cold,
+		iterable: &syncIterable{
+			iterator: iterator,
+		},
+	}
+}
+
+type syncIterable struct {
+	iterator Iterator
+}
+
+func (s *syncIterable) Iterator(ctx context.Context) Iterator {
+	return s.iterator
+}
+
 type MockObservable struct {
 	mock.Mock
 }
@@ -93,7 +110,7 @@ func mockIterators(in string) ([]*MockIterator, error) {
 		item, err := args(t)
 		if lastObs == t.observable {
 			if calls[index] == nil {
-				calls[index] = obs.On("Next", mock.Anything).Once().Arguments.Return(item, err)
+				calls[index] = obs.On("Next", mock.Anything).Once().Return(item, err)
 			} else {
 				calls[index].On("Next", mock.Anything).Once().Return(item, err)
 			}

--- a/observable_test.go
+++ b/observable_test.go
@@ -1648,6 +1648,15 @@ func TestSample_NotRepeatedItems(t *testing.T) {
 1
 2
 	0
+3
+4
+5
+	0
+6
+	0
+7
+8
+	0
 x
 	x
 `)
@@ -1658,9 +1667,9 @@ x
 	mockIterator2 := iterators[1]
 	mockObservable1 := new(MockObservable)
 	mockObservable1.On("Iterator", mock.Anything).Return(mockIterator2)
-	obs := FromIterator(mockIterator1).Sample(mockObservable1)
+	obs := newSyncObservable(mockIterator1).Sample(mockObservable1)
 
-	AssertObservable(t, obs, HasItems(2))
+	AssertObservable(t, obs, HasItems(2, 5, 6, 8))
 }
 
 func TestSample_SourceObsClosedBeforeIntervalFired(t *testing.T) {

--- a/observable_test.go
+++ b/observable_test.go
@@ -1643,7 +1643,6 @@ func TestSample(t *testing.T) {
 }
 
 func TestSample_NotRepeatedItems(t *testing.T) {
-	//iterators, err := mockIterators("1:1,1:2,2:0,1:3,1:4,1:5,2:0,1:close,2:close")
 	iterators, err := mockIterators(`
 1
 2

--- a/observable_test.go
+++ b/observable_test.go
@@ -1641,7 +1641,7 @@ func TestSample(t *testing.T) {
 }
 
 func TestSample_NotRepeatedItems(t *testing.T) {
-	iterators, err := mockIterators(`
+	observables := mockObservables(t, `
 1
 2
 	0
@@ -1660,12 +1660,7 @@ func TestSample_NotRepeatedItems(t *testing.T) {
 x
 	x
 `)
-	if err != nil {
-		assert.FailNow(t, err.Error())
-	}
-	mockIterator1 := iterators[0]
-	mockIterator2 := iterators[1]
-	obs := mockObservable(mockIterator1).Sample(mockObservable(mockIterator2))
+	obs := observables[0].Sample(observables[1])
 
 	AssertObservable(t, obs, HasItems(2, 5, 6, 8, 9))
 }
@@ -1773,7 +1768,7 @@ func TestStartWithObservable_Empty2(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	iterators, err := mockIterators(`
+	observables := mockObservables(t, `
 1
 2
 3
@@ -1783,21 +1778,19 @@ func TestTimeout(t *testing.T) {
 x
 	x
 `)
-	if err != nil {
-		assert.FailNow(t, err.Error())
-	}
-	mockIterator1 := iterators[0]
-	mockIterator2 := iterators[1]
-	obs := mockObservable(mockIterator1).Timeout(mockObservable(mockIterator2))
+	obs := observables[0].Timeout(observables[1])
+	AssertObservable(t, obs, HasItems(1, 2, 3))
+}
 
-	//
-	//
-	//ch := make(chan interface{}, 10)
-	//obs := FromChannel(ch).Timeout(Timer(WithDuration(2000 * time.Millisecond)))
-	//ch <- 1
-	//ch <- 2
-	//ch <- 3
-	//time.Sleep(time.Second)
-	//ch <- 4
+func TestTimeout_ClosedChannel(t *testing.T) {
+	observables := mockObservables(t, `
+1
+2
+3
+x
+	0
+	x
+`)
+	obs := observables[0].Timeout(observables[1])
 	AssertObservable(t, obs, HasItems(1, 2, 3))
 }

--- a/observablecreate.go
+++ b/observablecreate.go
@@ -409,8 +409,7 @@ func Start(f Supplier, fs ...Supplier) Observable {
 	return newColdObservableFromChannel(out)
 }
 
-// Timer returns an Observable that emits the zeroed value of a float64 after a
-// specified delay, and then completes.
+// Timer returns an Observable that emits an empty structure after a specified delay, and then completes.
 func Timer(d Duration) Observable {
 	out := make(chan interface{})
 	go func() {
@@ -419,7 +418,7 @@ func Timer(d Duration) Observable {
 		} else {
 			time.Sleep(d.duration())
 		}
-		out <- 0.
+		out <- struct{}{}
 		close(out)
 	}()
 	return newColdObservableFromChannel(out)

--- a/observablecreate_test.go
+++ b/observablecreate_test.go
@@ -298,19 +298,23 @@ func TestMerge(t *testing.T) {
 }
 
 func TestAmb(t *testing.T) {
-	ch1 := make(chan interface{}, 3)
-	ch2 := make(chan interface{}, 3)
-	obs := Amb(FromChannel(ch1), FromChannel(ch2))
-	ch1 <- 1
-	ch1 <- 2
-	ch1 <- 3
-	close(ch1)
-	time.Sleep(wait)
-	ch2 <- 10
-	ch2 <- 20
-	ch2 <- 30
-	close(ch2)
-	AssertObservable(t, obs, HasItems(1, 2, 3))
+	iterators, err := mockIterators(`
+1
+2
+x
+	3
+	4
+	x
+		5
+		x
+`)
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+	mockIterator1 := iterators[0]
+	mockIterator2 := iterators[1]
+	obs := Amb(mockObservable(mockIterator1), mockObservable(mockIterator2))
+	AssertObservable(t, obs, HasItems(1, 2))
 }
 
 // FIXME Not stable

--- a/observablecreate_test.go
+++ b/observablecreate_test.go
@@ -267,14 +267,14 @@ func TestTimer(t *testing.T) {
 
 	obs := Timer(d)
 
-	AssertObservable(t, obs, HasItems(float64(0)))
+	AssertObservable(t, obs, HasItems(struct{}{}))
 	d.AssertCalled(t, "duration")
 }
 
 func TestTimerWithNilDuration(t *testing.T) {
 	obs := Timer(nil)
 
-	AssertObservable(t, obs, HasItems(float64(0)))
+	AssertObservable(t, obs, HasItems(struct{}{}))
 }
 
 func TestMerge(t *testing.T) {
@@ -298,7 +298,7 @@ func TestMerge(t *testing.T) {
 }
 
 func TestAmb(t *testing.T) {
-	iterators, err := mockIterators(`
+	observables := mockObservables(t, `
 1
 2
 x
@@ -308,12 +308,7 @@ x
 		5
 		x
 `)
-	if err != nil {
-		assert.FailNow(t, err.Error())
-	}
-	mockIterator1 := iterators[0]
-	mockIterator2 := iterators[1]
-	obs := Amb(mockObservable(mockIterator1), mockObservable(mockIterator2))
+	obs := Amb(observables[0], observables[1])
 	AssertObservable(t, obs, HasItems(1, 2))
 }
 

--- a/observablecreate_test.go
+++ b/observablecreate_test.go
@@ -228,18 +228,6 @@ func TestFromStatefulIterable(t *testing.T) {
 	AssertObservable(t, obs, IsEmpty())
 }
 
-type statelessIterable struct {
-	count int
-}
-
-func (it *statelessIterable) Next(ctx context.Context) (interface{}, error) {
-	it.count++
-	if it.count < 3 {
-		return it.count, nil
-	}
-	return nil, &NoSuchElementError{}
-}
-
 func TestRange(t *testing.T) {
 	obs, err := Range(5, 3)
 	if err != nil {
@@ -312,30 +300,44 @@ x
 	AssertObservable(t, obs, HasItems(1, 2))
 }
 
-// FIXME Not stable
-//func TestCombineLatest(t *testing.T) {
-//	ch1 := make(chan interface{}, 10)
-//	ch2 := make(chan interface{}, 10)
-//	ch3 := make(chan interface{}, 10)
-//
-//	obs := CombineLatest(func(ii ...interface{}) interface{} {
-//		sum := 0
-//		for _, v := range ii {
-//			sum += v.(int)
-//		}
-//		return sum
-//	}, FromChannel(ch1), FromChannel(ch2), FromChannel(ch3))
-//
-//	//TODO AssertObservableEventually(t, obs, wait, IsEmpty())
-//	ch1 <- 1
-//	close(ch1)
-//	ch2 <- 2
-//	close(ch2)
-//	ch3 <- 3
-//	close(ch3)
-//	AssertObservable(t, obs, HasItems(6), HasNotRaisedAnyError())
-//	//TODO AssertObservableEventually(t, obs, wait, 6, 13 etc.)
-//}
+func TestCombineLatest(t *testing.T) {
+	observables := mockObservables(t, `
+1
+	10
+2
+	11
+102
+x
+	x
+`)
+	obs := CombineLatest(func(ii ...interface{}) interface{} {
+		sum := 0
+		for _, v := range ii {
+			sum += v.(int)
+		}
+		return sum
+	}, observables[0], observables[1:]...)
+	AssertObservable(t, obs, HasItems(11, 12, 13, 113), HasNotRaisedAnyError())
+}
+
+func TestCombineLatest_Error(t *testing.T) {
+	observables := mockObservables(t, `
+1
+	10
+2
+	e
+102
+x
+`)
+	obs := CombineLatest(func(ii ...interface{}) interface{} {
+		sum := 0
+		for _, v := range ii {
+			sum += v.(int)
+		}
+		return sum
+	}, observables[0], observables[1:]...)
+	AssertObservable(t, obs, HasItems(11, 12), HasRaisedAnError())
+}
 
 // FIXME
 //Context("when creating a hot observable with FromEventSource operator without back-pressure strategy", func() {


### PR DESCRIPTION
Implementation of a _causality_ testing API based on a DSL. For example:
```go
observables := mockObservables(t, `
1
	2
3
	4
x
	x
`)
```
Each column represents an observable emitting item. The first observable will produce the items `1`, `3` and will close (`x`) whereas the second observable will produce the items `2`, `4` and will close.
This code will produce observables from which iterating over the internal iterator does guarantee sequentiality. It means `1` will be handled before `2`, `2` before `3` etc. regardless of the execution context.

This allows us to get rid of `time.Sleep` in some tests which leads to deterministic tests.

Last but not least, sending an item `e` in the DSL creates pushes an error item.