### PR TITLE
Fix flatmap race condition using incorrect observable from apply()

### DIFF
--- a/observable/flatmap.go
+++ b/observable/flatmap.go
@@ -45,10 +45,10 @@ func flatObservedSequence(out chan interface{}, o Observable, apply func(interfa
 		sequence = apply(element)
 		count++
 		wg.Add(1)
-		go func() {
+		go func(copy Observable) {
 			defer wg.Done()
-			<-(sequence.Subscribe(*emissionObserver))
-		}()
+			<-(copy.Subscribe(*emissionObserver))
+		}(sequence)
 
 		if count%maxInParallel == 0 {
 			wg.Wait()


### PR DESCRIPTION
FlatMap() generates a closure/goroutine corresponding to each element, which run concurrently depending on the parallelism parameter. However, each closure shares the `sequence` variable, which causes issues when `sequence` is rewritten before the previous value of `sequence` is subscribed to. This causes weird non-deterministic behavior and 'skipping' Observables before they're done.

The fix is to pass each goroutine its own copy of `sequence` at time of creation.

More info on this kind of bug:
https://blog.cloudflare.com/a-go-gotcha-when-closures-and-goroutines-collide/