### PR TITLE
Stopping the Take Operator Stream When it Receives all the Expected Items

### DIFF
--- a/iterable_eventsource.go
+++ b/iterable_eventsource.go
@@ -35,12 +35,16 @@ func newEventSourceIterable(ctx context.Context, next <-chan Item, strategy Back
 					fallthrough
 				case Block:
 					for _, observer := range it.observers {
-						observer <- item
+						if !item.SendContext(ctx, observer) {
+							return
+						}
 					}
 				case Drop:
 					for _, observer := range it.observers {
 						select {
 						default:
+						case <-ctx.Done():
+							return
 						case observer <- item:
 						}
 					}

--- a/observable_operator.go
+++ b/observable_operator.go
@@ -2378,11 +2378,14 @@ type takeOperator struct {
 	takeCount int
 }
 
-func (op *takeOperator) next(ctx context.Context, item Item, dst chan<- Item, _ operatorOptions) {
-	if op.takeCount < int(op.nth) {
-		op.takeCount++
-		item.SendContext(ctx, dst)
+func (op *takeOperator) next(ctx context.Context, item Item, dst chan<- Item, operatorOptions operatorOptions) {
+	if op.takeCount >= int(op.nth) {
+		operatorOptions.stop()
+		return
 	}
+
+	op.takeCount++
+	item.SendContext(ctx, dst)
 }
 
 func (op *takeOperator) err(ctx context.Context, item Item, dst chan<- Item, operatorOptions operatorOptions) {

--- a/observable_operator_test.go
+++ b/observable_operator_test.go
@@ -2039,7 +2039,12 @@ func Test_Observable_Take_Interval(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	obs := Interval(WithDuration(time.Nanosecond), WithContext(ctx)).Take(3)
-	Assert(ctx, t, obs, HasItems(0, 1, 2))
+	Assert(ctx, t, obs, CustomPredicate(func(items []interface{}) error {
+		if len(items) != 3 {
+			return errors.New("3 items are expected")
+		}
+		return nil
+	}))
 }
 
 func Test_Observable_TakeLast(t *testing.T) {

--- a/observable_operator_test.go
+++ b/observable_operator_test.go
@@ -2034,6 +2034,14 @@ func Test_Observable_Take(t *testing.T) {
 	Assert(ctx, t, obs, HasItems(1, 2, 3))
 }
 
+func Test_Observable_Take_Interval(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	obs := Interval(WithDuration(time.Nanosecond), WithContext(ctx)).Take(3)
+	Assert(ctx, t, obs, HasItems(0, 1, 2))
+}
+
 func Test_Observable_TakeLast(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Closes https://github.com/ReactiveX/RxGo/issues/262