### PR TITLE
📝 docs: Fixed typo for func call of WithBufferedChannel.

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -9,7 +9,7 @@ observable.Map(func(_ context.Context, i interface{}) (interface{}, error) {
 	return i.(int) * 10, nil
 }, rxgo.WithContext(),
    rxgo.WithCPUPool(),
-   rxgo.WihtBufferedChannel(1))
+   rxgo.WithBufferedChannel(1))
 ```
 
 ## WithBufferedChannel


### PR DESCRIPTION
Very minor typo fix for now, addresses #274 .

**About me**
Still looking at other bug fixes/documentation that I can start with. I come from an rxjs background, and have recently learned Go; so I'm still learning the peculiarities of Golang the language. I am still looking at how I might be able to use RxGo on my projects.

