### PR TITLE
SendContext fix

### DIFF
--- a/item.go
+++ b/item.go
@@ -98,10 +98,15 @@ func (i Item) SendBlocking(ch chan<- Item) {
 // It returns a boolean to indicate whether the item was sent.
 func (i Item) SendContext(ctx context.Context, ch chan<- Item) bool {
 	select {
-	case <-ctx.Done():
+	case <-ctx.Done(): // context's done channel has a priority
 		return false
-	case ch <- i:
-		return true
+	default:
+		select {
+		case <-ctx.Done():
+			return false
+		case ch <- i:
+			return true
+		}
 	}
 }
 

--- a/item.go
+++ b/item.go
@@ -98,7 +98,7 @@ func (i Item) SendBlocking(ch chan<- Item) {
 // It returns a boolean to indicate whether the item was sent.
 func (i Item) SendContext(ctx context.Context, ch chan<- Item) bool {
 	select {
-	case <-ctx.Done(): // context's done channel has a priority
+	case <-ctx.Done(): // Context's done channel has the highest priority
 		return false
 	default:
 		select {

--- a/item_test.go
+++ b/item_test.go
@@ -53,6 +53,15 @@ func Test_Item_SendContext_True(t *testing.T) {
 	assert.True(t, Of(5).SendContext(ctx, ch))
 }
 
+func Test_Item_SendContext_False(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ch := make(chan Item, 1)
+	defer close(ch)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.False(t, Of(5).SendContext(ctx, ch))
+}
+
 func Test_Item_SendNonBlocking(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ch := make(chan Item, 1)


### PR DESCRIPTION
SendContext didn't check if context is done first. Instead, in case ctx is done and channel to send has a free buffer, it chose randomly either to return false or send value to the channel.

Added a test that failed randomly on previous version of SendContext.

Changes to be committed:
	modified:   item.go
	modified:   item_test.go