### PR TITLE
fix(docs): Fix incorrect WithObservationStrategy reference in docs

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -33,13 +33,13 @@ rxgo.WithContext(ctx)
 * Lazy (default): consume when an Observer starts to subscribe.
 
 ```go
-rxgo.WithObservation(rxgo.Lazy)
+rxgo.WithObservationStrategy(rxgo.Lazy)
 ```
 
 * Eager: consumer when the Observable is created:
 
 ```go
-rxgo.WithObservation(rxgo.Eager)
+rxgo.WithObservationStrategy(rxgo.Eager)
 ```
 
 ## WithErrorStrategy


### PR DESCRIPTION
The `WithObservationStrategy` documentation section currently specifies
`WithObservation` in the code samples, so this PR updates to resolve the mismatch.

Signed-off-by: Nick Groszewski <groszewn@gmail.com>