### PR TITLE
Fix race condition issue in combineLatest

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -93,10 +93,10 @@ func CombineLatest(f FuncN, observables []Observable, opts ...Option) Observable
 						errCh <- struct{}{}
 						return
 					}
+					mutex.Lock()
 					if s[i] == nil {
 						atomic.AddUint32(&counter, 1)
 					}
-					mutex.Lock()
 					s[i] = item.V
 					if atomic.LoadUint32(&counter) == size {
 						next <- Of(f(s...))


### PR DESCRIPTION
This is to fix a race condition in the combineLatest function.
I was getting nil pointer exceptions when using combineLatest callback function `f FuncN` with multiple observables which are also using combineLatest.

From what I can tell, the race condition is caused when one observable has incremented the counter, but has not yet set the cache variable `s[i] = item.V` 
Meanwhile, another observable is checking if the counter is equal to the number of observables `atomic.LoadUint32(&counter) == size` and then calling the callback function with the cache variable which now includes a nil value.

By moving the counter increment into the lock, this should fix the race condition issue.
