### PR TITLE
Add Support for Custom Error Assertion

### DIFF
--- a/doc/assert.md
+++ b/doc/assert.md
@@ -115,3 +115,21 @@ rxgo.Assert(ctx, t, observable, rxgo.CustomPredicate(func(items []interface{}) e
 	return nil
 }))
 ```
+
+### CustomErrorPredicate
+
+Implement a custom error predicate
+
+```go
+errorPredicate := func(observedErrors []error) error {
+	if len(observedErrors) != 1 {
+		return errors.New("expecting one error only")
+	}
+	var expected *json.SyntaxError
+	if errors.As(observedErrors[0], &expected) {
+		return nil
+	}
+	return fmt.Errorf("Expected error %v but found %v", json.SyntaxError{}, observedErrors[0])
+}
+rxgo.Assert(ctx, t, obs, rxgo.CustomErrorPredicate(errorPredicate))
+```


### PR DESCRIPTION
Today the package provides Assertion helpers for errors of three type:
- assert the observable has an error (any error)
- assert the observable has one error
- assert the observable has several specific errors

These assertions are useful, but could be either too broad or too narrow. Having an assertion that is very precise on the error (that returns true to a fully equality comparison) makes tests brittle, having an assertion that matches any error makes it difficult to know that the failure is right one

This PR adds an additional way to match errors through the introduction of  `ErrorPredicate`